### PR TITLE
Fixed the midi event mapping

### DIFF
--- a/desktop.piano/vendor/index.html
+++ b/desktop.piano/vendor/index.html
@@ -28,7 +28,7 @@ function KeyIn(e){
 window.onload=function(){
   window.addEventListener("message", (event) => {
     // console.log('eventdata', event.data)
-    synth.send([0x90,event.data[2] , 100])
+    synth.send([event.data[0], event.data[1], event.data[2]])
     //synth.send([0x90, 62, 1, 100])
   }, false);
   Init();


### PR DESCRIPTION
The synth.send should be able to send all 3 items in event data. When using midi device to control a synth, all 3 items matter, so hard-coded magic numbers should be avoided.